### PR TITLE
fix: 광고를 콘텐츠 영역 안으로 이동하여 애드센스 정책 위반 수정

### DIFF
--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -9,8 +9,10 @@ interface TemplateProps {
 const Template = ({ children }: TemplateProps) => {
   return (
     <Background>
-      <Content>{children}</Content>
-      <DisplayAds />
+      <Content>
+        {children}
+        <DisplayAds />
+      </Content>
     </Background>
   )
 }


### PR DESCRIPTION
DisplayAds 컴포넌트가 Content 밖(회색 배경 영역)에 렌더링되어
"게시자 콘텐츠가 없는 화면에 Google 게재 광고" 정책 위반 발생.
광고를 Content 내부로 이동하여 콘텐츠와 함께 렌더링되도록 수정.