### PR TITLE
fix: 콘텐츠 없는 화면에 광고 노출되는 애드센스 정책 위반 수정

### DIFF
--- a/src/pages/hotpot/detail/index.tsx
+++ b/src/pages/hotpot/detail/index.tsx
@@ -11,6 +11,7 @@ import { Recipe } from '../types';
 const HotpotDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const [recipe, setRecipe] = useState<Recipe | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!id) return;
@@ -36,12 +37,13 @@ const HotpotDetailPage = () => {
         });
         await updateDoc(ref, { view: increment(1) });
       }
+      setLoading(false);
     };
     fetchDetail();
   }, [id]);
 
   return (
-    <Template>
+    <Template showAd={!loading && recipe !== null}>
       <Wrapper>
         <Bar title={recipe?.name} />
         <Badge size="2" color="gray">

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -4,14 +4,15 @@ import DisplayAds from "../components/DisplayAd"
 
 interface TemplateProps {
   children: ReactNode
+  showAd?: boolean
 }
 
-const Template = ({ children }: TemplateProps) => {
+const Template = ({ children, showAd = true }: TemplateProps) => {
   return (
     <Background>
       <Content>
         {children}
-        <DisplayAds />
+        {showAd && <DisplayAds />}
       </Content>
     </Background>
   )
@@ -33,6 +34,7 @@ const Background = styled.div`
 `
 const Content = styled.div`
   display: flex;
+  flex-direction: column;
   width: 100%;
 
   @media (min-width: 400px) {


### PR DESCRIPTION
## Summary
- `HotpotDetailPage`에 `loading` 상태 추가 — Firebase 데이터 로드 완료 전까지 광고 미표시
- `Template`에 `showAd?: boolean` prop 추가 — 페이지별 광고 노출 제어 가능
- `Content` 컨테이너에 `flex-direction: column` 추가 — 광고가 콘텐츠 옆이 아닌 아래에 위치하도록 수정

## Test plan
- [ ] `/hotpot/detail/:id` 진입 시 데이터 로드 전에 광고가 표시되지 않는지 확인
- [ ] 데이터 로드 완료 후 광고가 정상 표시되는지 확인
- [ ] 존재하지 않는 id로 접근 시 광고가 표시되지 않는지 확인
- [ ] 다른 페이지에서 광고 레이아웃(콘텐츠 아래)이 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)