### PR TITLE
feat: add About and Privacy pages, update footer and home page layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -17,14 +17,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@radix-ui/themes@3.2.1/styles.css" />
 
     <!--구글 아이콘-->
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"
-    />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"
-    />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"
@@ -74,7 +66,11 @@
     </script>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>
+      <h1>트위터 맛집 검색기</h1>
+      <p>트위터(X)에서 언급된 맛집을 검색할 수 있는 서비스입니다. 광고 없는 진짜 맛집을 찾아보세요.</p>
+      <p>이 서비스를 이용하려면 JavaScript를 활성화해 주세요.</p>
+    </noscript>
     <div id="root"></div>
   </body>
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -30,4 +30,14 @@
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://twitter-michelin.web.app/about</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://twitter-michelin.web.app/privacy</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
 </urlset>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,10 +1,12 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import AboutPage from './pages/about';
 import GroupPage from './pages/group';
 import GroupListPage from './pages/group-list';
 import HomePage from './pages/home';
 import HotpotPage from './pages/hotpot';
 import HotpotDetailPage from './pages/hotpot/detail';
 import LogPage from './pages/log';
+import PrivacyPage from './pages/privacy';
 import RecommendPage from './pages/recommend';
 import SmallShopPage from './pages/small-shop';
 
@@ -20,6 +22,8 @@ const AppRouter = () => {
         <Route path="/hotpot" element={<HotpotPage />} />
         <Route path="/hotpot/detail/:id" element={<HotpotDetailPage />} />
         <Route path="/smallshop" element={<SmallShopPage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,38 @@
+import { Flex, Text } from '@radix-ui/themes';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Footer = () => {
+  return (
+    <FooterWrapper>
+      <Flex direction="row" gap="4" justify="center" wrap="wrap">
+        <Link to="/about">
+          <Text size="1" style={{ color: '#A0AEC0' }}>
+            서비스 소개
+          </Text>
+        </Link>
+        <Link to="/privacy">
+          <Text size="1" style={{ color: '#A0AEC0' }}>
+            개인정보처리방침
+          </Text>
+        </Link>
+        <Link to="/log">
+          <Text size="1" style={{ color: '#A0AEC0' }}>
+            변경 로그
+          </Text>
+        </Link>
+      </Flex>
+      <Text size="1" style={{ color: '#CBD5E0', marginTop: '6px', display: 'block', textAlign: 'center' }}>
+        © 2022 트위터 맛집 검색기
+      </Text>
+    </FooterWrapper>
+  );
+};
+
+export default Footer;
+
+const FooterWrapper = styled.footer`
+  width: 100%;
+  padding: 16px 0 20px;
+  text-align: center;
+`;

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,0 +1,166 @@
+import { Spacer } from '@chakra-ui/react';
+import { Badge, Card, Flex, Text } from '@radix-ui/themes';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import Template from '../../templates';
+import Bar from '../group/components/Bar';
+
+const AboutPage = () => {
+  return (
+    <Template>
+      <AboutContainer>
+        <Bar title="서비스 소개" />
+
+        <Section>
+          <Text size="5" weight="bold" as="p">
+            트위터 맛집 검색기
+          </Text>
+          <Spacer height="8px" />
+          <Text size="3" as="p" style={{ color: '#4A5568' }}>
+            광고 없는 진짜 맛집을 트위터(X)에서 찾아드립니다.
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold" as="p">
+            서비스 소개
+          </Text>
+          <Spacer height="10px" />
+          <Text size="2" as="p" style={{ lineHeight: '1.8' }}>
+            트위터(X)는 솔직한 맛집 후기와 추천이 활발하게 공유되는
+            플랫폼입니다. 하지만 원하는 맛집을 검색하려면 트위터 내 검색 기능의
+            한계로 인해 불편함이 많았습니다. 트위터 맛집 검색기는 트위터에서
+            언급된 맛집 정보를 쉽게 검색하고 탐색할 수 있도록 만들어진
+            서비스입니다.
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold" as="p">
+            주요 기능
+          </Text>
+          <Spacer height="10px" />
+          <Flex direction="column" gap="3">
+            <Card>
+              <Flex direction="column" gap="1">
+                <Text size="2" weight="bold">
+                  🔍 맛집 검색
+                </Text>
+                <Text size="2" style={{ color: '#4A5568' }}>
+                  가게 이름, 지역, 음식 종류로 트위터에서 언급된 맛집을 검색할
+                  수 있습니다.
+                </Text>
+              </Flex>
+            </Card>
+            <Card>
+              <Flex direction="column" gap="1">
+                <Text size="2" weight="bold">
+                  👀 그룹별 보기
+                </Text>
+                <Text size="2" style={{ color: '#4A5568' }}>
+                  음식 종류, 지역 등 다양한 카테고리별로 묶인 맛집 그룹을 탐색할
+                  수 있습니다.
+                </Text>
+              </Flex>
+            </Card>
+            <Card>
+              <Flex direction="column" gap="1">
+                <Text size="2" weight="bold">
+                  ✨ 추천 해시태그
+                </Text>
+                <Text size="2" style={{ color: '#4A5568' }}>
+                  트위터에서 맛집 탐색에 유용한 해시태그를 랜덤으로
+                  추천해드립니다.
+                </Text>
+              </Flex>
+            </Card>
+            <Card>
+              <Flex direction="column" gap="1">
+                <Text size="2" weight="bold">
+                  🔔 소상공인 가게 찾기
+                </Text>
+                <Text size="2" style={{ color: '#4A5568' }}>
+                  소상공인 가게를 지도에서 확인할 수 있습니다.
+                </Text>
+              </Flex>
+            </Card>
+            <Card>
+              <Flex direction="column" gap="1">
+                <Text size="2" weight="bold">
+                  🍲 훠궈 소스 백과사전
+                </Text>
+                <Text size="2" style={{ color: '#4A5568' }}>
+                  하이디라오에서 즐길 수 있는 훠궈 소스의 특징과 키워드를 정리한
+                  백과사전입니다.
+                </Text>
+              </Flex>
+            </Card>
+          </Flex>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold" as="p">
+            기술 정보
+          </Text>
+          <Spacer height="10px" />
+          <Flex gap="2" wrap="wrap">
+            <Badge color="blue">React</Badge>
+            <Badge color="blue">TypeScript</Badge>
+            <Badge color="orange">Firebase</Badge>
+            <Badge color="green">Supabase</Badge>
+            <Badge color="purple">Kakao Maps</Badge>
+          </Flex>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold" as="p">
+            문의 및 제보
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p" style={{ lineHeight: '1.8' }}>
+            새로운 맛집 정보 제보, 오류 신고, 소상공인 가게 홍보 등의 문의는
+            아래 링크를 통해 주세요.
+          </Text>
+          <Spacer height="8px" />
+          <a
+            href="https://innerstella.notion.site/affa459f47294cb599b9ccb8e8a9d9ef"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Text
+              size="2"
+              style={{ color: '#e5534b', textDecoration: 'underline' }}
+            >
+              문의 페이지 바로가기 →
+            </Text>
+          </a>
+        </Section>
+
+        <Section>
+          <Link to="/privacy">
+            <Text size="2" style={{ color: '#718096' }}>
+              개인정보처리방침
+            </Text>
+          </Link>
+        </Section>
+
+        <Spacer height="40px" />
+      </AboutContainer>
+    </Template>
+  );
+};
+
+export default AboutPage;
+
+const AboutContainer = styled.div`
+  width: 100%;
+  min-height: 100dvh;
+  padding: 0 25px;
+  background-color: #fafafa;
+  font-family: 'SUIT', sans-serif;
+  box-sizing: border-box;
+`;
+
+const Section = styled.div`
+  margin-bottom: 28px;
+`;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -2,6 +2,7 @@ import { Spacer } from '@chakra-ui/react';
 import { Flex, RadioCards, Text } from '@radix-ui/themes';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
+import Footer from '../../components/Footer';
 import Search from '../../components/PlaceSearch';
 import Template from '../../templates';
 import LOG_DATA from '../log/data';
@@ -18,54 +19,57 @@ const HomePage = () => {
     <Template>
       <PopupBanner />
       <MainContainer>
-        <Header />
-        <Spacer height="60px" />
-        <Search page="home" />
-        <Spacer height="35px" />
-        <Flex width="350px" justify="center">
-          <RadioCards.Root>
-            <Flex direction="row" justify="between" width="325px">
-              <Link to="/group-list">
-                <RadioCards.Item value="group" style={{ width: '150px' }}>
-                  <Text size="2" weight="bold">
-                    👀 그룹별로 보기
-                  </Text>
-                </RadioCards.Item>
-              </Link>
-              <Link to="/recommend">
-                <RadioCards.Item value="recommend">
-                  <Text size="2" weight="bold">
-                    ✨ 추천 해시태그 보기
-                  </Text>
-                </RadioCards.Item>
-              </Link>
-            </Flex>
-            <Flex direction="row" justify="between" width="325px">
-              <Link to="/smallshop">
-                <RadioCards.Item value="smallshop" style={{ width: '150px' }}>
-                  <Text size="2" weight="bold">
-                    🔔 소상공인 찾기
-                  </Text>
-                </RadioCards.Item>
-              </Link>
-              <Link to="/hotpot">
-                <RadioCards.Item value="sauce">
-                  <Text size="2" weight="bold">
-                    🍲 훠궈 소스 백과사전
-                  </Text>
-                </RadioCards.Item>
-              </Link>
-            </Flex>
-          </RadioCards.Root>
-        </Flex>
-        <Spacer height="35px" />
-        <Coffee />
-        <Spacer height="35px" />
-        <center>
-          <Banner />
-        </center>
-        <Spacer height="20px" />
-        <Noti badgeText={version} text={<>{changes}</>} />
+        <div>
+          <Header />
+          <Spacer height="60px" />
+          <Search page="home" />
+          <Spacer height="35px" />
+          <Flex width="350px" justify="center">
+            <RadioCards.Root>
+              <Flex direction="row" justify="between" width="325px">
+                <Link to="/group-list">
+                  <RadioCards.Item value="group" style={{ width: '150px' }}>
+                    <Text size="2" weight="bold">
+                      👀 그룹별로 보기
+                    </Text>
+                  </RadioCards.Item>
+                </Link>
+                <Link to="/recommend">
+                  <RadioCards.Item value="recommend">
+                    <Text size="2" weight="bold">
+                      ✨ 추천 해시태그 보기
+                    </Text>
+                  </RadioCards.Item>
+                </Link>
+              </Flex>
+              <Flex direction="row" justify="between" width="325px">
+                <Link to="/smallshop">
+                  <RadioCards.Item value="smallshop" style={{ width: '150px' }}>
+                    <Text size="2" weight="bold">
+                      🔔 소상공인 찾기
+                    </Text>
+                  </RadioCards.Item>
+                </Link>
+                <Link to="/hotpot">
+                  <RadioCards.Item value="sauce">
+                    <Text size="2" weight="bold">
+                      🍲 훠궈 소스 백과사전
+                    </Text>
+                  </RadioCards.Item>
+                </Link>
+              </Flex>
+            </RadioCards.Root>
+          </Flex>
+          <Spacer height="35px" />
+          <Coffee />
+          <Spacer height="35px" />
+          <center>
+            <Banner />
+          </center>
+          <Spacer height="20px" />
+          <Noti badgeText={version} text={<>{changes}</>} />
+        </div>
+        <Footer />
       </MainContainer>
     </Template>
   );
@@ -75,8 +79,11 @@ export default HomePage;
 
 const MainContainer = styled.div`
   width: 100%;
-  height: 100dvh;
+  min-height: 100dvh;
   padding: 0 25px;
   background-color: #fafafa;
   font-family: 'SUIT', sans-serif;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `;

--- a/src/pages/privacy/index.tsx
+++ b/src/pages/privacy/index.tsx
@@ -1,0 +1,145 @@
+import { Spacer } from '@chakra-ui/react';
+import { Text } from '@radix-ui/themes';
+import styled from 'styled-components';
+import Template from '../../templates';
+import Bar from '../group/components/Bar';
+
+const PrivacyPage = () => {
+  return (
+    <Template>
+      <PrivacyContainer>
+        <Bar title="개인정보처리방침" />
+        <Section>
+          <Text size="3" weight="bold">
+            1. 개인정보의 처리 목적
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            트위터 맛집 검색기(이하 "서비스")는 다음의 목적을 위해 개인정보를
+            처리합니다. 처리한 개인정보는 다음의 목적 이외의 용도로는 사용되지
+            않으며, 이용 목적이 변경될 시에는 별도의 동의를 받는 등 필요한
+            조치를 이행할 예정입니다.
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            - 서비스 이용 통계 분석 및 서비스 개선
+            <br />- 맞춤형 광고 제공 (Google AdSense)
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold">
+            2. 수집하는 개인정보 항목 및 수집 방법
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            본 서비스는 이용자로부터 직접 개인정보를 수집하지 않습니다. 단,
+            아래와 같이 자동으로 수집되는 정보가 있습니다.
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            <strong>자동 수집 항목:</strong>
+            <br />
+            - IP 주소, 브라우저 유형, 방문 일시, 서비스 이용 기록 (Google
+            Analytics)
+            <br />- 쿠키(Cookie) 및 유사 기술을 통해 수집되는 광고 관련 정보
+            (Google AdSense)
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold">
+            3. 개인정보의 처리 및 보유 기간
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            서비스는 법령에 따른 개인정보 보유·이용기간 또는 정보주체로부터
+            개인정보를 수집 시에 동의받은 개인정보 보유·이용기간 내에서
+            개인정보를 처리·보유합니다.
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            Google Analytics 데이터는 Google의 데이터 보유 정책에 따라
+            처리됩니다.
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold">
+            4. 제3자 제공
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            본 서비스는 다음과 같은 제3자에게 이용자 정보를 제공하거나 공유할 수
+            있습니다.
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            <strong>Google LLC (Google Analytics, Google AdSense)</strong>
+            <br />
+            - 제공 목적: 서비스 이용 통계 분석, 맞춤형 광고 제공
+            <br />
+            - 제공 항목: 서비스 이용 기록, 쿠키 정보
+            <br />
+            - 보유 기간: Google의 개인정보 처리방침에 따름
+            <br />- Google 개인정보 처리방침:{' '}
+            <a
+              href="https://policies.google.com/privacy"
+              target="_blank"
+              rel="noreferrer"
+            >
+              https://policies.google.com/privacy
+            </a>
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold">
+            5. 쿠키(Cookie) 사용
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            본 서비스는 Google Analytics 및 Google AdSense를 통해 쿠키를
+            사용합니다. 쿠키는 웹사이트를 운영하는 데 이용되는 서버가 이용자의
+            컴퓨터 브라우저에게 보내는 소량의 정보입니다. 이용자는 브라우저
+            설정을 통해 쿠키 사용을 거부할 수 있으나, 일부 서비스 이용이 제한될
+            수 있습니다.
+          </Text>
+        </Section>
+
+        <Section>
+          <Text size="3" weight="bold">
+            6. 이용자의 권리
+          </Text>
+          <Spacer height="8px" />
+          <Text size="2" as="p">
+            이용자는 언제든지 자신의 개인정보에 대한 열람, 정정, 삭제, 처리정지
+            요청을 할 수 있습니다. 광고 맞춤설정을 원하지 않는 경우 Google 광고
+            설정에서 조정하실 수 있습니다.
+          </Text>
+        </Section>
+        <Spacer height="40px" />
+      </PrivacyContainer>
+    </Template>
+  );
+};
+
+export default PrivacyPage;
+
+const PrivacyContainer = styled.div`
+  width: 100%;
+  min-height: 100dvh;
+  padding: 0 25px;
+  background-color: #fafafa;
+  font-family: 'SUIT', sans-serif;
+  box-sizing: border-box;
+
+  a {
+    color: #e5534b;
+    text-decoration: underline;
+  }
+`;
+
+const Section = styled.div`
+  margin-bottom: 24px;
+`;


### PR DESCRIPTION

<img width="1220" height="118" alt="image" src="https://github.com/user-attachments/assets/8ce477f4-b063-4922-9155-738420b542aa" />

<hr/>

- [[에드센스 승인 팁] 필수 페이지 작성 가이드｜개인정보처리방침](https://el-luna.tistory.com/entry/google-adsense-policy-pages)

<img width="702" height="337" alt="image" src="https://github.com/user-attachments/assets/b321c021-88d3-40f9-8851-b829d9ac079b" />

<html><head></head><body><p>구글 애드센스 "가치가 없는 콘텐츠" 거절은 주로 다음 이유들로 발생합니다. 코드를 분석한 결과 핵심 문제들을 발견했습니다.</p>
<hr>
<h2>현재 진단된 문제들</h2>
<h3>1. 필수 페이지 부재 (가장 중요)</h3>
<p>애드센스 심사에서 <strong>개인정보처리방침(Privacy Policy)</strong> 은 거의 필수입니다. 현재 없음.</p>
<ul>
<li>개인정보처리방침 페이지</li>
<li>서비스 소개(About) 페이지</li>
<li>문의 페이지 (Notion 링크는 있지만 사이트 내 페이지 필요)</li>
</ul>
<h3>2. <code>lang="en"</code> 오류 (<code>public/index.html:2</code>)</h3>
<pre><code class="language-html">&lt;html lang="en"&gt;  &lt;!-- 한국어 사이트인데 en으로 설정됨 --&gt;
</code></pre>
<p>구글 크롤러 혼란 야기. <code>lang="ko"</code> 로 변경 필요.</p>
<h3>3. 콘텐츠 얇음 (Thin Content)</h3>
<p>현재 페이지들이 대부분 <strong>검색 인터페이스 + DB 조회</strong>로만 구성. 구글은 도구만 있는 사이트를 "콘텐츠가 없다"고 판단하는 경향이 있음.</p>
<ul>
<li>메인 페이지: 검색바 + 버튼들만 있음</li>
<li>각 페이지에 서비스 설명 텍스트가 없음</li>
</ul>
<h3>4. <code>&lt;noscript&gt;</code> 태그 (<code>index.html:77</code>)</h3>
<pre><code class="language-html">&lt;noscript&gt;You need to enable JavaScript to run this app.&lt;/noscript&gt;
</code></pre>
<p>구글 봇이 JS 없이 크롤링할 때 보이는 내용이 없음. (react-snap이 완전히 해결해주지는 않음)</p>
<hr>
<h2>우선순위별 작업 목록</h2>

순위 | 작업 | 난이도 | 중요도
-- | -- | -- | --
1 | 개인정보처리방침 페이지 추가 | 낮음 | 매우 높음
2 | lang="ko" 수정 | 매우 낮음 | 높음
3 | 서비스 소개(About) 페이지 추가 | 낮음 | 높음
4 | 각 페이지에 설명 텍스트 추가 | 중간 | 중간
5 | <noscript> 한국어 + 설명 개선 | 매우 낮음 | 낮음
